### PR TITLE
Refactor/just audio backend

### DIFF
--- a/lib/logic/core.dart
+++ b/lib/logic/core.dart
@@ -1,15 +1,16 @@
 import 'package:json_annotation/json_annotation.dart';
-import 'package:just_audio/just_audio.dart';
 import 'package:pffs/logic/storage.dart';
 import 'package:path/path.dart' as p;
 
 part 'core.g.dart';
 
+enum PlaylistMode { off, one, all }
+
 @JsonSerializable()
 class PlaylistConf {
   final List<TrackConf> tracks;
   bool? shuffled;
-  LoopMode? loopMode;
+  PlaylistMode? loopMode;
 
   PlaylistConf({required this.tracks});
 

--- a/lib/logic/core.dart
+++ b/lib/logic/core.dart
@@ -1,7 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:just_audio/just_audio.dart';
 import 'package:pffs/logic/storage.dart';
 import 'package:path/path.dart' as p;
-import 'package:media_kit/media_kit.dart';
 
 part 'core.g.dart';
 
@@ -9,7 +9,7 @@ part 'core.g.dart';
 class PlaylistConf {
   final List<TrackConf> tracks;
   bool? shuffled;
-  PlaylistMode? loopMode;
+  LoopMode? loopMode;
 
   PlaylistConf({required this.tracks});
 

--- a/lib/logic/core.g.dart
+++ b/lib/logic/core.g.dart
@@ -12,19 +12,19 @@ PlaylistConf _$PlaylistConfFromJson(Map<String, dynamic> json) => PlaylistConf(
           .toList(),
     )
       ..shuffled = json['shuffled'] as bool?
-      ..loopMode = $enumDecodeNullable(_$PlaylistModeEnumMap, json['loopMode']);
+      ..loopMode = $enumDecodeNullable(_$LoopModeEnumMap, json['loopMode']);
 
 Map<String, dynamic> _$PlaylistConfToJson(PlaylistConf instance) =>
     <String, dynamic>{
       'tracks': instance.tracks,
       'shuffled': instance.shuffled,
-      'loopMode': _$PlaylistModeEnumMap[instance.loopMode],
+      'loopMode': _$LoopModeEnumMap[instance.loopMode],
     };
 
-const _$PlaylistModeEnumMap = {
-  PlaylistMode.none: 'off',
-  PlaylistMode.single: 'one',
-  PlaylistMode.loop: 'all',
+const _$LoopModeEnumMap = {
+  LoopMode.off: 'off',
+  LoopMode.one: 'one',
+  LoopMode.all: 'all',
 };
 
 TrackConf _$TrackConfFromJson(Map<String, dynamic> json) => TrackConf(

--- a/lib/logic/core.g.dart
+++ b/lib/logic/core.g.dart
@@ -12,19 +12,19 @@ PlaylistConf _$PlaylistConfFromJson(Map<String, dynamic> json) => PlaylistConf(
           .toList(),
     )
       ..shuffled = json['shuffled'] as bool?
-      ..loopMode = $enumDecodeNullable(_$LoopModeEnumMap, json['loopMode']);
+      ..loopMode = $enumDecodeNullable(_$PlaylistModeEnumMap, json['loopMode']);
 
 Map<String, dynamic> _$PlaylistConfToJson(PlaylistConf instance) =>
     <String, dynamic>{
       'tracks': instance.tracks,
       'shuffled': instance.shuffled,
-      'loopMode': _$LoopModeEnumMap[instance.loopMode],
+      'loopMode': _$PlaylistModeEnumMap[instance.loopMode],
     };
 
-const _$LoopModeEnumMap = {
-  LoopMode.off: 'off',
-  LoopMode.one: 'one',
-  LoopMode.all: 'all',
+const _$PlaylistModeEnumMap = {
+  PlaylistMode.off: 'off',
+  PlaylistMode.one: 'one',
+  PlaylistMode.all: 'all',
 };
 
 TrackConf _$TrackConfFromJson(Map<String, dynamic> json) => TrackConf(

--- a/lib/logic/state.dart
+++ b/lib/logic/state.dart
@@ -95,7 +95,7 @@ class PlayerState extends ChangeNotifier {
 
   String _playlistName = "Unknown";
   PlayingObject _playingObject = PlayingObject.nothing;
-  LoopMode _loopMode = LoopMode.all;
+  PlaylistMode _loopMode = PlaylistMode.all;
   List<int>? _shuffleIndexes;
   Uri? _artUri;
   MediaInfo? _track;
@@ -108,7 +108,7 @@ class PlayerState extends ChangeNotifier {
   Stream<bool> get completedStream =>
       _player.processingStateStream.map((s) => s == ProcessingState.completed);
   String? get playlistName => _playlistName;
-  LoopMode get loopMode => _loopMode;
+  PlaylistMode get loopMode => _loopMode;
   PlaylistConf? get currentPlaylist => _playlist;
   MediaInfo? get currentTrack => _track;
   Future<Uri?> get currentArtUri async {
@@ -145,7 +145,7 @@ class PlayerState extends ChangeNotifier {
     _playingObject = type;
     _playlist = p;
     _playlistName = name;
-    _loopMode = p.loopMode ?? LoopMode.all;
+    _loopMode = p.loopMode ?? PlaylistMode.all;
     _index = startIndex;
     _shuffled = p.shuffled ?? false;
     // play
@@ -336,25 +336,25 @@ class PlayerState extends ChangeNotifier {
     notifyListeners();
   }
 
-  void changeLoopMode() {
+  void changePlaylistMode() {
     if (_player.playing == false) {
       _player.stop();
     }
     // update in player
     switch (_loopMode) {
-      case LoopMode.off:
+      case PlaylistMode.off:
         {
-          _loopMode = LoopMode.all;
+          _loopMode = PlaylistMode.all;
           break;
         }
-      case LoopMode.all:
+      case PlaylistMode.all:
         {
-          _loopMode = LoopMode.one;
+          _loopMode = PlaylistMode.one;
           break;
         }
-      case LoopMode.one:
+      case PlaylistMode.one:
         {
-          _loopMode = LoopMode.off;
+          _loopMode = PlaylistMode.off;
           break;
         }
     }
@@ -431,9 +431,9 @@ class PlayerState extends ChangeNotifier {
       if (e == ProcessingState.completed) {
         TrackConf? item;
         // handle loop mode
-        if (_loopMode == LoopMode.one) {
+        if (_loopMode == PlaylistMode.one) {
           item = _fetchCurrent();
-        } else if (_loopMode == LoopMode.off &&
+        } else if (_loopMode == PlaylistMode.off &&
             _index == _playlist!.tracks.length - 1) {
           item = null;
         } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,14 @@
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:flutter/material.dart';
+import 'package:just_audio_media_kit/just_audio_media_kit.dart';
 import 'package:pffs/logic/state.dart';
 import 'package:pffs/pages/playlists.dart';
 import 'package:pffs/widgets/mini_player.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'pages/library.dart';
-import 'package:media_kit/media_kit.dart' as audio;
+import 'package:just_audio/just_audio.dart' as audio;
 import 'package:pffs/logic/service/service_linux.dart' as linux_service;
 import 'package:pffs/logic/service/service_windows.dart' as windows_service;
 import 'package:pffs/logic/service/service_android.dart' as android_service;
@@ -18,8 +19,14 @@ void main() async {
   // init key-value store
   final prefs = await SharedPreferences.getInstance();
   // init player if desktop app
-  audio.MediaKit.ensureInitialized();
-  var player = audio.Player();
+  if (Platform.isLinux || Platform.isWindows) {
+    JustAudioMediaKit.ensureInitialized(windows: true, linux: true);
+    JustAudioMediaKit.title = 'pffs';
+  }
+  var player = audio.AudioPlayer(
+    handleInterruptions: false,
+    handleAudioSessionActivation: false,
+  );
   // init state
   var libState = LibraryState(prefs);
   var playerState = PlayerState(prefs, player);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,10 +23,7 @@ void main() async {
     JustAudioMediaKit.ensureInitialized(windows: true, linux: true);
     JustAudioMediaKit.title = 'pffs';
   }
-  var player = audio.AudioPlayer(
-    handleInterruptions: false,
-    handleAudioSessionActivation: false,
-  );
+  var player = audio.AudioPlayer();
   // init state
   var libState = LibraryState(prefs);
   var playerState = PlayerState(prefs, player);
@@ -39,7 +36,6 @@ void main() async {
     // handle audio session
     final session = await AudioSession.instance;
     await session.configure(const AudioSessionConfiguration.music());
-    android_service.handleSession(session, playerState);
     // handle audio service
     var _ = await AudioService.init(
       builder: () => android_service.AudioHandler(playerState),

--- a/lib/widgets/full_player.dart
+++ b/lib/widgets/full_player.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_popup/flutter_popup.dart';
-import 'package:just_audio/just_audio.dart' as audio;
+import 'package:pffs/logic/core.dart';
 import 'package:pffs/logic/state.dart';
 import 'package:pffs/widgets/effect_modifier.dart';
 import 'package:provider/provider.dart';
@@ -27,13 +27,13 @@ class _FullPlayerState extends State<FullPlayer> {
       final primaryColour = colours.primary;
       // loopMode icon
       Widget loopModeIcon;
-      if (state.loopMode == audio.LoopMode.one) {
+      if (state.loopMode == PlaylistMode.one) {
         loopModeIcon = Badge(
           backgroundColor: primaryColour,
           label: const Text('1'),
           child: const Icon(Icons.loop_rounded),
         );
-      } else if (state.loopMode == audio.LoopMode.all) {
+      } else if (state.loopMode == PlaylistMode.all) {
         loopModeIcon = Icon(Icons.loop_rounded, color: primaryColour);
       } else {
         loopModeIcon = const Icon(Icons.loop_rounded);
@@ -66,7 +66,7 @@ class _FullPlayerState extends State<FullPlayer> {
             ),
             IconButton(
               onPressed: () {
-                state.changeLoopMode();
+                state.changePlaylistMode();
               },
               icon: loopModeIcon,
               iconSize: 25,

--- a/lib/widgets/full_player.dart
+++ b/lib/widgets/full_player.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_popup/flutter_popup.dart';
-import 'package:media_kit/media_kit.dart' as audio;
+import 'package:just_audio/just_audio.dart' as audio;
 import 'package:pffs/logic/state.dart';
 import 'package:pffs/widgets/effect_modifier.dart';
 import 'package:provider/provider.dart';
@@ -27,13 +27,13 @@ class _FullPlayerState extends State<FullPlayer> {
       final primaryColour = colours.primary;
       // loopMode icon
       Widget loopModeIcon;
-      if (state.loopMode == audio.PlaylistMode.single) {
+      if (state.loopMode == audio.LoopMode.one) {
         loopModeIcon = Badge(
           backgroundColor: primaryColour,
           label: const Text('1'),
           child: const Icon(Icons.loop_rounded),
         );
-      } else if (state.loopMode == audio.PlaylistMode.loop) {
+      } else if (state.loopMode == audio.LoopMode.all) {
         loopModeIcon = Icon(Icons.loop_rounded, color: primaryColour);
       } else {
         loopModeIcon = const Icon(Icons.loop_rounded);

--- a/lib/widgets/mini_player.dart
+++ b/lib/widgets/mini_player.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:pffs/logic/core.dart';
 import 'package:pffs/logic/state.dart';
 import 'package:pffs/widgets/effect_modifier.dart';
 import 'package:pffs/widgets/full_player.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_popup/flutter_popup.dart';
 import 'dart:io';
-import 'package:just_audio/just_audio.dart' as audio;
 
 class MiniPlayerAppBar extends StatefulWidget implements PreferredSizeWidget {
   const MiniPlayerAppBar({super.key});
@@ -33,13 +33,13 @@ class _MiniPlayerAppBarState extends State<MiniPlayerAppBar> {
       final primaryColour = Theme.of(context).colorScheme.primary;
       // loopMode icon
       Widget loopModeIcon;
-      if (state.loopMode == audio.LoopMode.one) {
+      if (state.loopMode == PlaylistMode.one) {
         loopModeIcon = Badge(
           backgroundColor: primaryColour,
           label: const Text('1'),
           child: const Icon(Icons.loop_rounded),
         );
-      } else if (state.loopMode == audio.LoopMode.all) {
+      } else if (state.loopMode == PlaylistMode.all) {
         loopModeIcon = Icon(Icons.loop_rounded, color: primaryColour);
       } else {
         loopModeIcon = const Icon(Icons.loop_rounded);
@@ -92,7 +92,7 @@ class _MiniPlayerAppBarState extends State<MiniPlayerAppBar> {
             color: state.shuffleOrder ? primaryColour : null),
         IconButton(
           onPressed: () {
-            state.changeLoopMode();
+            state.changePlaylistMode();
           },
           icon: loopModeIcon,
         ),

--- a/lib/widgets/mini_player.dart
+++ b/lib/widgets/mini_player.dart
@@ -5,7 +5,7 @@ import 'package:pffs/widgets/full_player.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_popup/flutter_popup.dart';
 import 'dart:io';
-import 'package:media_kit/media_kit.dart' as audio;
+import 'package:just_audio/just_audio.dart' as audio;
 
 class MiniPlayerAppBar extends StatefulWidget implements PreferredSizeWidget {
   const MiniPlayerAppBar({super.key});
@@ -33,13 +33,13 @@ class _MiniPlayerAppBarState extends State<MiniPlayerAppBar> {
       final primaryColour = Theme.of(context).colorScheme.primary;
       // loopMode icon
       Widget loopModeIcon;
-      if (state.loopMode == audio.PlaylistMode.single) {
+      if (state.loopMode == audio.LoopMode.one) {
         loopModeIcon = Badge(
           backgroundColor: primaryColour,
           label: const Text('1'),
           child: const Icon(Icons.loop_rounded),
         );
-      } else if (state.loopMode == audio.PlaylistMode.loop) {
+      } else if (state.loopMode == audio.LoopMode.all) {
         loopModeIcon = Icon(Icons.loop_rounded, color: primaryColour);
       } else {
         loopModeIcon = const Icon(Icons.loop_rounded);

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import audio_service
 import audio_session
+import just_audio
 import media_kit_libs_macos_audio
 import path_provider_foundation
 import shared_preferences_foundation
@@ -15,6 +16,7 @@ import sqflite
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   MediaKitLibsMacosAudioPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosAudioPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -440,6 +440,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.8.0"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      sha256: a49e7120b95600bd357f37a2bb04cd1e88252f7cdea8f3368803779b925b1049
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.42"
+  just_audio_media_kit:
+    dependency: "direct main"
+    description:
+      name: just_audio_media_kit
+      sha256: "9f3517213dfc7bbaf6980656feb66c35600f114c7efc0b5b3f4476cd5c18b45e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.6"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: "0243828cce503c8366cc2090cefb2b3c871aa8ed2f520670d76fd47aa1ab2790"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: "9a98035b8b24b40749507687520ec5ab404e291d2b0937823ff45d92cb18d448"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.13"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   media_kit_libs_audio: ^1.0.5
   audio_service: ^0.18.15
   flutter_popup: ^3.3.0
+  just_audio: ^0.9.42
+  just_audio_media_kit: ^2.0.6
   mpris_service:
     git:
       url: https://github.com/alexmercerind/mpris_service.git


### PR DESCRIPTION
Use new implementation of state.dart with just_audio as a backend. This fixes background service errors on Android related to media_kit library keeping all improvements of the new code.